### PR TITLE
Handling of Location headers

### DIFF
--- a/navigator.go
+++ b/navigator.go
@@ -2,6 +2,7 @@ package halgo
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -108,6 +109,25 @@ func (n navigator) Followf(rel string, params P) navigator {
 		path:       relations,
 		rootUri:    n.rootUri,
 	}
+}
+
+// Location follows the Location header from a response.  It makes the URI
+// absolute, if necessary.
+func (n navigator) Location(resp *http.Response) (navigator, error) {
+	_, exists := resp.Header["Location"]
+	if !exists {
+		return n, fmt.Errorf("Response didn't contain a Location header")
+	}
+	loc := resp.Header.Get("Location")
+	lurl, err := makeAbsoluteIfNecessary(loc, n.rootUri)
+	if err != nil {
+		return n, err
+	}
+	return navigator{
+		HttpClient: n.HttpClient,
+		path:       []relation{},
+		rootUri:    lurl,
+	}, nil
 }
 
 // url returns the URL of the tip of the follow queue. Will follow the


### PR DESCRIPTION
This adds a method called `Location` to the `navigator` type.  This is useful for handling responses from `POST` requests in cases where the response includes a `Location` header ([as it should](https://en.wikipedia.org/wiki/HTTP_location) when creating new resources or redirecting).

I initially considered just creating a new `navigator` instance myself.  But since the `Location` header can be a relative URI, it is generally necessary to transform it into an absolute URI.  For that reason, I thought it was best to avoid having to repeat that (potentially error prone) code and simply write a helper method to do what was necessary.