### PR TITLE
Adding an Options method

### DIFF
--- a/navigator.go
+++ b/navigator.go
@@ -190,6 +190,21 @@ func (n navigator) Get() (*http.Response, error) {
 	return n.HttpClient.Do(req)
 }
 
+// Options performs an OPTIONS request on the tip of the follow queue.
+func (n navigator) Options() (*http.Response, error) {
+	url, err := n.url()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := newHalRequest("OPTIONS", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return n.HttpClient.Do(req)
+}
+
 // PostForm performs a POST request on the tip of the follow queue with
 // the given form data.
 //

--- a/navigator_test.go
+++ b/navigator_test.go
@@ -47,6 +47,11 @@ func TestNavigatingToUnknownLink(t *testing.T) {
 		t.Fatal("Expected error to be raised for missing link")
 	}
 
+	_, err = Navigator(ts.URL).Follow("missing").Options()
+	if err == nil {
+		t.Fatal("Expected error to be raised for OPTIONS call to missing link")
+	}
+
 	if err.Error() != "Response didn't contain link with relation: missing" {
 		t.Errorf("Unexpected error message: %s", err.Error())
 	}
@@ -77,6 +82,13 @@ func TestGettingTheRoot(t *testing.T) {
 	if hits["/"] != 1 {
 		t.Errorf("Expected 1 request to /, got %d", hits["/"])
 	}
+
+	// If Get works, Options should work as well
+	res, err = nav.Options()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 }
 
 func TestFollowingATemplatedLink(t *testing.T) {


### PR DESCRIPTION
This adds another method called `Options` that uses the `OPTIONS` method.  This is mainly for completeness since `OPTIONS` is pretty meaningless from a hypermedia standpoint.  But it does allow the client to perform the `OPTIONS` call and look at the result contained in the response and/or check for an error condition.
